### PR TITLE
Adiciona action para publicar imagem no dockerhub

### DIFF
--- a/.github/workflows/push-docker-image.yml
+++ b/.github/workflows/push-docker-image.yml
@@ -1,0 +1,39 @@
+name: Publish Docker image
+
+# Executar sempre que uma release for publicada.
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout no código fonte
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      # Login no docker hub com as credenciais configuradas na organização no github.
+      - name: Log in to Docker Hub
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Extrai metadados da release: tags e labels.
+      # Usa o namespace do docker hub configurado na organizaçào do github.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ secrets.DOCKERHUB_ORGANIZATION }}/laia
+
+      # Faz o build e push da imagem.
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Seguindo o padrão de [outro repositório da organização](https://github.com/DadosAbertosDeFeira/iac-docker-tika/blob/main/.github/workflows/main.yml), esta action requer:
- secrets.DOCKERHUB_USERNAME
- secrets.DOCKERHUB_TOKEN
- secrets.DOCKERHUB_ORGANIZATION

Tendo a configuração correta destes, a imagem será construida e publicada sempre que uma release for publicada no repositório. Qualquer coisa, só falar :)