### PR TITLE
Atualiza o black no pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,6 @@ repos:
   hooks:
   - id: isort
 - repo: https://github.com/ambv/black
-  rev: 21.7b0
+  rev: 22.3.0
   hooks:
   - id: black


### PR DESCRIPTION
A versão atual do Black está causando a quebra do pipeline.